### PR TITLE
feat(myaccount): add external support url option

### DIFF
--- a/langs/en_US/sellyoursaas.lang
+++ b/langs/en_US/sellyoursaas.lang
@@ -283,6 +283,7 @@ High=High
 YourText=Please enter your text here...
 TicketSent=Your ticket was received. We will proceed it as soon as possible.
 FailedToSentTicketPleaseTryLater=Failed to submit your ticket. Please try later...
+SupportURLExternal=To open a support ticket, please follow the instructions available on <a href="%s" target="_support">this page</a>.
 FailedToCreateCardRecord=Failed to validate your card.
 AlreadyHaveAnAccount=Already have an account?
 LoginAction=Login

--- a/langs/es_ES/sellyoursaas.lang
+++ b/langs/es_ES/sellyoursaas.lang
@@ -255,6 +255,7 @@ High=Elevado
 YourText=Por favor ingrese su texto aquí...
 TicketSent=Su ticket ha sido recibido. Lo trataremos lo antes posible.
 FailedToSentTicketPleaseTryLater=Error al enviar su ticket. Por favor intentelo de nuevo más tarde...
+SupportURLExternal=Para abrir un ticket de soporte, siga las instrucciones disponibles en <a href="%s" target="_support">esta página</a>.
 FailedToCreateCardRecord=Error al validar tu tarjeta.
 AlreadyHaveAnAccount=¿Ya tiene una cuenta?
 LoginAction=Iniciar sesión

--- a/langs/fr_FR/sellyoursaas.lang
+++ b/langs/fr_FR/sellyoursaas.lang
@@ -271,6 +271,7 @@ High=Elevé
 YourText=Merci d'entrer votre texte ici...
 TicketSent=Votre ticket a été reçu. Nous allons le traiter dès que possible.
 FailedToSentTicketPleaseTryLater=Echec de l'envoi de votre ticket. Merci de réessayer plus tard...
+SupportURLExternal=Pour ouvrir un ticket de support, suivez les instructions disponibles sur <a href="%s" target="_support">cette page</a>.
 FailedToCreateCardRecord=Echec de la validation de votre carte.
 AlreadyHaveAnAccount=Vous avez déjà un compte?
 LoginAction=Se logguer

--- a/myaccount/.gitignore
+++ b/myaccount/.gitignore
@@ -1,1 +1,2 @@
 /source
+main.inc.php

--- a/myaccount/index.php
+++ b/myaccount/index.php
@@ -44,6 +44,7 @@ include ('./mainmyaccount.inc.php');
 $res=0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (! $res && ! empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) $res=@include($_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php");
+if (! $res && ! empty($_SERVER["DOCUMENT_ROOT"])) $res=@include($_SERVER["DOCUMENT_ROOT"]."/main.inc.php");
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
 $tmp=empty($_SERVER['SCRIPT_FILENAME'])?'':$_SERVER['SCRIPT_FILENAME'];$tmp2=realpath(__FILE__); $i=strlen($tmp)-1; $j=strlen($tmp2)-1;
 while($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i]==$tmp2[$j]) { $i--; $j--; }
@@ -6430,8 +6431,23 @@ if ($mode == 'support')
 	<!-- END PAGE HEAD -->
 	<!-- END PAGE HEADER-->';
 
+    $sellyoursaassupporturl = $conf->global->SELLYOURSAAS_SUPPORT_URL;
+    if (! empty($mythirdpartyaccount->array_options['options_domain_registration_page'])
+        && $mythirdpartyaccount->array_options['options_domain_registration_page'] != $conf->global->SELLYOURSAAS_MAIN_DOMAIN_NAME)
+    {
+        $newnamekey = 'SELLYOURSAAS_SUPPORT_URL-'.$mythirdpartyaccount->array_options['options_domain_registration_page'];
+        if (! empty($conf->global->$newnamekey)) $sellyoursaassupporturl = $conf->global->$newnamekey;
+    }
 
-	print '
+	if ($sellyoursaassupporturl) {
+
+		print '<div class="row" id="supporturl"><div class="col-md-12"><div class="portlet light">';
+		print $langs->trans("SupportURLExternal", $sellyoursaassupporturl).'<br />'."\n";
+		print '</div></div></div>';
+
+	} else {
+
+		print '
 			    <div class="row" id="choosechannel">
 			      <div class="col-md-12">
 
@@ -6622,6 +6638,7 @@ if ($mode == 'support')
 
 			    </div> <!-- END ROW -->
 			';
+	}
 
 	if ($action != 'presend')
 	{


### PR DESCRIPTION
Support multiple URL by cloud domain, example: 
- Other setup > **SELLYOURSAAS_SUPPORT_URL** > value "https://global.support.cloud"
- Other setup > **SELLYOURSAAS_SUPPORT_URL-domain1.cloud** > value "https://support.domain1.cloud"
- Other setup > **SELLYOURSAAS_SUPPORT_URL-domain2.cloud**  > value "https://help.domain2.cloud"

After declare other setup option, "Myaccount > Support" page displays a text inviting to follow the declared link:
![image](https://user-images.githubusercontent.com/470612/71715633-5f37c180-2e12-11ea-901f-dc2a3ae50255.png)
