### PR TITLE
FIX : email was not set when creating a new instance from user account

### DIFF
--- a/myaccount/register_instance.php
+++ b/myaccount/register_instance.php
@@ -494,6 +494,8 @@ else
 			dol_print_error_email('FETCHTP'.$reusesocid, $tmpthirdparty->error, $tmpthirdparty->errors, 'alert alert-error');
 			exit(-1);
 		}
+
+		$email = $tmpthirdparty->email;
 	}
 	else
 	{


### PR DESCRIPTION
Resulting in empty APPEMAIL