### PR TITLE
fix(remote_server): incorrect default variable name for listenport

### DIFF
--- a/scripts/remote_server_launcher.sh
+++ b/scripts/remote_server_launcher.sh
@@ -49,7 +49,7 @@ if [[ "x$remoteserverlistenip" == "x" ]]; then
 fi
 remoteserverlistenport=`grep 'remoteserverlistenport=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 if [[ "x$remoteserverlistenport" == "x" ]]; then
-	remoteserverlistenip="8080"
+	remoteserverlistenport="8080"
 fi
 
 if [ "x$1" == "xstart" ]; then


### PR DESCRIPTION
"remote_server_launcher" service doesn't start anymore if we don't put the new var "remoteserverlistenport" in sellyoursaas configuration file.

```txt
systemd[1]: Starting LSB: Start/stop remote_server_launcher...
remote_server_launcher[22554]: **** /etc/init.d/remote_server_launcher
remote_server_launcher[22554]: Switch on directory /home/admin/wwwroot/dolibarr_sellyoursaas/scripts
remote_server_launcher[22554]: Server started with php -S 8080: -t remote_server remote_server/index.php
remote_server_launcher[22554]: Logs of server will be in /var/log/remote_server.log
systemd[1]: Started LSB: Start/stop remote_server_launcher.
remote_server_launcher[22554]: Invalid address: 8080:
```

 introduced by https://github.com/eldy/sellyoursaas/commit/6f126be191c9bd7b48fed3816e9fcf73bf45a7e6#diff-bbdcabe7172189acf0c1afbeee9ed9f7468078030fc594bb39e879d93a2a4e36R52