### PR TITLE
set cookie before sending headers

### DIFF
--- a/myaccount/register.php
+++ b/myaccount/register.php
@@ -247,11 +247,11 @@ $arrayofjs=array(
 
 $title = $langs->trans("Registration").($tmpproduct->label?' ('.$tmpproduct->label.')':'');
 
-llxHeader($head, $title, '', '', 0, 0, $arrayofjs, array(), '', 'register');
-
 $prefix=dol_getprefix('');
 $cookieregistrationa='DOLREGISTERA_'.$prefix;
 if (empty($_COOKIE[$cookieregistrationa])) setcookie($cookieregistrationa, 1, 0, "/", null, false, true);	// Cookie to count nb of registration from this computer
+
+llxHeader($head, $title, '', '', 0, 0, $arrayofjs, array(), '', 'register');
 
 ?>
 


### PR DESCRIPTION
Just because of this php message : PHP Warning:  Cannot modify header information - headers already sent by (output started at .../... mainmyaccount.inc.php:315) in .../... register.php on line 243