### PR TITLE
remove deprecated php7.4

### DIFF
--- a/myaccount/antispamimage.php
+++ b/myaccount/antispamimage.php
@@ -57,7 +57,7 @@ $letters = 'aAbBCDeEFgGhHJKLmMnNpPqQRsStTuVwWXYZz2345679';
 $number = strlen($letters);
 $string = '';
 for ($i = 0; $i < $length; $i++) {
-	$string .= $letters{mt_rand(0, $number - 1)};
+	$string .= $letters[mt_rand(0, $number - 1)];
 }
 //print $string;
 


### PR DESCRIPTION
Array or string offset access with curly braces deprecated in PHP 7.4. Targeting PHP 8.0.0.