### PR TITLE
Fix : Missing const STATUS_DRAFT

### DIFF
--- a/class/packages.class.php
+++ b/class/packages.class.php
@@ -52,6 +52,8 @@ class Packages extends CommonObject
 	 * @var string String with name of icon for packages
 	 */
 	public $picto = 'label';
+	
+	const STATUS_DRAFT = 0;
 
 
 	/**


### PR DESCRIPTION
Leads to a fatal error when cloning a package