### PR TITLE
FIX - improve robustness of git_update_sources.sh

### DIFF
--- a/scripts/git_update_sources.sh
+++ b/scripts/git_update_sources.sh
@@ -20,7 +20,7 @@ export currentpath=$(dirname "$0")
 
 echo "Update git dirs found into $1 and generate the tgz image."
 
-for dir in `ls -d $1/* | grep -v "tgz\|zstd"`
+for dir in $(find "$1" -mindepth 1 -maxdepth 1 -type d)
 do
 	# If a subdir is given, discard if not subdir
 	if [ "x$2" != "x" -a "x$2" != "xall" ]; then
@@ -30,7 +30,7 @@ do
 	fi
 
     echo -- Process dir $dir
-    cd $dir
+    cd $dir || continue
 	if [ $? -eq 0 ]; then
 		export gitdir=`basename $dir`
 


### PR DESCRIPTION
- only include directories in case someone creates a file in the $1 directory
- continue if cd $dir fails (could happen for instance if a subdirectory of "$1" has a space in its name, which is not recommended anyway but… who knows?)