### PR TITLE
NEW: dans la procédure d'install, fichier /etc/skel/.my.cnf

### DIFF
--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
@@ -485,6 +485,14 @@ sudo vi /etc/skel/.ssh/authorized_keys_support
 
 Thus any new linux account created (those of customer instances) will be accessible by the administrator(s).
 
+Also create a per-user mysql configuration file in */etc/skel/.my.cnf* to enable SellYourSaas end users to use the
+mysql client from their ssh shell connection.
+
+[source, bash]
+---------------
+printf '[client]\nprotocol=tcp' >> /etc/skel/.my.cnf
+---------------
+
 
 === Add alias
 

--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - FR.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - FR.asciidoc
@@ -432,7 +432,16 @@ sudo chmod -R go-rwx /etc/skel/.ssh
 sudo vi /etc/skel/.ssh/authorized_keys_support
 ---------------
 
-Ainsi tout nouveau compte account created (those of customer instances) will be accessible by the administrator(s).
+Ainsi, l'administrateur pourra accéder à tout nouveau compte créé (ceux des instances clients).
+
+Créez également un fichier de configuration mysql dans */etc/skel/.my.cnf* afin de permettre aux clients finaux de
+votre SellYourSaas d'utiliser le client mysql en console depuis une connexion shell ssh.
+
+[source, bash]
+---------------
+printf '[client]\nprotocol=tcp' >> /etc/skel/.my.cnf
+---------------
+
 
 
 


### PR DESCRIPTION
## Rationale
When connected to an ssh shell as an end user, I couldn't connect to mysql.

First connect to the end user ssh shell:
```
ssh osuww@xx.withY.zz
# authenticate…
Welcome to Ubuntu NN.MM (GNU/Linux …………)
```

Then try to open a local mysql connection:
```
mysql dbLLLLL -udbUUUUU -p

ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (13 "Permission denied")
```
The error occurs because by default the client tries to use unix sockets.

Adding a `.my.cnf` to tell mysql to use tcp solves the error above.

## Other considerations
I am aware that you can easily open a mysql connection remotely (using the commands provided in the "useful links" tab), but sometimes you are in the ssh shell and you need to run a script that uses mysql, or there can be other use cases… it cannot hurt to solve this problem (as far as I can see, it creates no security hole because the user could create `.my.cnf` themselves if they wanted, so this would have no positive or negative influence on any vulnerability related to the mysql client).

I also think that it could be interesting to enable unix sockets for SellYourSaas end users (only to their own database of course), and if we did that (I haven't tried yet but it shouldn't be too hard), the `.my.cnf` would be useless.