### PR TITLE
NEW: if document/install.lock present in the git dir, restore it after packaging app

### DIFF
--- a/scripts/git_update_sources.sh
+++ b/scripts/git_update_sources.sh
@@ -57,6 +57,8 @@ do
 	    fi
 	   
 		echo "Clean some dirs to save disk spaces"
+		has_install_lock=''
+		if [[ -f documents/install.lock ]]; then has_install_lock='1'; fi
 		rm -fr documents/*
 		rm -fr dev/ test/ doc/ htdocs/includes/ckeditor/ckeditor/adapters htdocs/includes/ckeditor/ckeditor/samples
 		rm -fr htdocs/public/test
@@ -87,8 +89,11 @@ do
 			# Delete archive in other format
 			rm $dir/../$gitdir.tar.zst 2>/dev/null
 		fi
-	
-	    cd -
+
+		# restore previously deleted install.lock
+		if [[ -n "$has_install_lock" ]]; then touch 'documents/install.lock'; fi
+
+		cd -
 	fi
 done
 


### PR DESCRIPTION
## Rationale

When the CRON job updates the packages, it removes all documents including `install.lock` if present. If the model application for the package is externally accessible, this could make the model application vulnerable.

This PR detects the presence of an `install.lock` file and recreates it immediately after the package archive has been created. This still isn't perfect (there is still the very short time window when the package is being archived, during which `install.lock` isn't present).