### PR TITLE
NEW: hook 'getRegisterPageForm' enabling external modules to replace the registration form completely

### DIFF
--- a/myaccount/register.php
+++ b/myaccount/register.php
@@ -301,8 +301,17 @@ llxHeader($head, $title, '', '', 0, 0, $arrayofjs, array(), '', 'register', '', 
 	<img id="waitMaskImg" width="100px" src="<?php echo 'ajax-loader.gif'; ?>" alt="Loading" />
 </div>
 
+<?php
 
-<div class="large">
+$parameters = array('tmpproduct' => $tmpproduct);
+// return values of this hook:
+// 0 = resPrint appended to the content of the page
+// 1 = page contents replaced with resPrint
+$reshook = $hookmanager->executeHooks('getRegisterPageForm', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+$hookGetRegisterPageFormResPrint = $hookmanager->resPrint;
+if ($reshook == 0) {
+?>
+	<div class="large">
 		<?php
 		$sellyoursaasdomain = $conf->global->SELLYOURSAAS_MAIN_DOMAIN_NAME;
 		$sellyoursaasname = $conf->global->SELLYOURSAAS_NAME;
@@ -879,6 +888,12 @@ llxHeader($head, $title, '', '', 0, 0, $arrayofjs, array(), '', 'register', '', 
 </div>
 
 
+<?php
+}
+if ($reshook >= 0) {
+	print $hookGetRegisterPageFormResPrint;
+}
+?>
 
 
 <script type="text/javascript" language="javascript">

--- a/myaccount/register.php
+++ b/myaccount/register.php
@@ -303,7 +303,25 @@ llxHeader($head, $title, '', '', 0, 0, $arrayofjs, array(), '', 'register', '', 
 
 <?php
 
-$parameters = array('tmpproduct' => $tmpproduct);
+$parameters = array(
+	'partner' => $partner,
+	'partnerkey' => $partnerkey,
+	'plan' => $plan,
+	'sldAndSubdom' => $sldAndSubdomain,
+	'tldid' => $tldid,
+	'origin' => $origin,
+	'reusecontractid' => $reusecontractid,
+	'reusesocid' => $reusesocid,
+	'fromsocid' => $fromsocid,
+	'disablecusto' => $disablecustomeremail,
+	'extcss' => $extcss,
+	'domainname' => $domainname,
+	'productid' => $productid,
+	'productref' => $productref,
+	'tmppackage' => $tmppackage,
+	'mythirdparty' => $mythirdparty,
+	'tmpproduct' => $tmpproduct
+);
 // return values of this hook:
 // 0 = resPrint appended to the content of the page
 // 1 = page contents replaced with resPrint

--- a/myaccount/register.php
+++ b/myaccount/register.php
@@ -325,7 +325,7 @@ $parameters = array(
 // return values of this hook:
 // 0 = resPrint appended to the content of the page
 // 1 = page contents replaced with resPrint
-$reshook = $hookmanager->executeHooks('getRegisterPageForm', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+$reshook = $hookmanager->executeHooks('sellyoursaasGetRegisterPageForm', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 $hookGetRegisterPageFormResPrint = $hookmanager->resPrint;
 if ($reshook == 0) {
 ?>


### PR DESCRIPTION
As discussed previously, we would like to be able to completely redesign the registration form (not just CSS but also DOM).
So this hook basically provides all variables retrieved by GETPOST and can replace almost the entire page.