### PR TITLE
FIX : Substitution key assignment

### DIFF
--- a/myaccount/index.php
+++ b/myaccount/index.php
@@ -1691,7 +1691,7 @@ if ($action == 'updateurl') {	// update URL from the tab "Domain"
 
 				$substitutionarray=getCommonSubstitutionArray($langs, 0, null, $contract);
 				$substitutionarray['__HASH__']=$hash;
-
+				$substitutionarray['__SELLYOURSAAS_ACCOUNT_URL__'] = getDolGlobalString('SELLYOURSAAS_ACCOUNT_URL');
 				complete_substitutions_array($substitutionarray, $langs, $contract);
 
 				$subject = make_substitutions($arraydefaultmessage->topic, $substitutionarray, $langs);


### PR DESCRIPTION
Issue with the email template link
Since the constant "SELLYOURSAAS_ACCOUNT_URL" was not properly translated, the entire href attribute of the <a> tag was empty in the email body.
I therefore added it to the substitution key table, just like `__HASH__` on the line above.