### PR TITLE
Condition to deploy php fpm must be based on phpfpm parameter in /etc…

### DIFF
--- a/scripts/action_deploy_undeploy.sh
+++ b/scripts/action_deploy_undeploy.sh
@@ -1289,7 +1289,7 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 	export phpfpmconf="/etc/php/$phpversion/fpm/pool.d/sellyoursaas/$fqn.phpfpm.conf"
 	export phpfpmservicename="sellyoursaas-php$phpversion-fpm-$fqn.service"
 	export phpfpmservice="/etc/systemd/system/$phpfpmservicename"
-	if [ -d /etc/php/$phpversion/fpm/pool.d/sellyoursaas ]; then
+	if [ "x$phpfpm" != "x" ]; then
 		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** Create php fpm conf $phpfpmconf from $fpmpoolfiletemplate"
 		if [[ -s $phpfpmconf ]]
 		then


### PR DESCRIPTION
…/sellyoursaas.conf

This bug generates a deployment error if a deployment with php fpm has been used and then disabled in  /etc/sellyoursaas.conf. In this case the folder etc/php/$phpversion/fpm/pool.d/sellyoursaas exists but we are deploying mod_php