### PR TITLE
Allow adding of attachment, if enabled in email template

### DIFF
--- a/class/sellyoursaasutils.class.php
+++ b/class/sellyoursaasutils.class.php
@@ -450,7 +450,9 @@ class SellYourSaasUtils
 													$invoicediroutput = $conf->facture->dir_output;
 													$fileparams = dol_most_recent_file($invoicediroutput . '/' . $invoice->ref, preg_quote($invoice->ref, '/').'[^\-]+');
 													$file = $fileparams['fullname'];
-													$file = '';		// Disable attachment of invoice in emails
+													if (empty($arraydefaultmessage->joinfiles)) {
+														$file = '';               // Disable attachment of invoice in emails if template joinfiles = 0
+													}
 
 													if ($file) {
 														$listofpaths=array($file);
@@ -2137,7 +2139,9 @@ class SellYourSaasUtils
 							$invoicediroutput = $conf->facture->dir_output;
 							$fileparams = dol_most_recent_file($invoicediroutput . '/' . $invoice->ref, preg_quote($invoice->ref, '/').'[^\-]+');
 							$file = $fileparams['fullname'];
-							$file = '';		// Disable attachment of invoice in emails
+							if (empty($arraydefaultmessage->joinfiles)) {
+								$file = '';               // Disable attachment of invoice in emails if template joinfiles = 0
+							}
 
 							if ($file) {
 								$listofpaths=array($file);


### PR DESCRIPTION
The following emails are currently sent without attachment (hardcoded). The change gives control to the setting in the email template and allows attaching the invoice document.

YourLinkForYourPayment
InvoicePaymentSuccess
InvoicePaymentFailure